### PR TITLE
add success conditional to publish workflow

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build_and_upload_images:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
Adds a condition that ensures the test workflow is successful before publishing the Docker images. This is being done in preparation for activating the workflow on the main repository.